### PR TITLE
Fix serializer validation errors on album creation

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,4 +18,4 @@ gunicorn = "*"
 django-environ = "*"
 
 [requires]
-python_version = "3.8"
+python_version = "3.12"

--- a/record_collection_be/serializers.py
+++ b/record_collection_be/serializers.py
@@ -14,14 +14,14 @@ class ArtistSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = Artist
-        fields = ('artist', 'notes', 'photo_url', 'albums', 'artist_url')
+        fields = ('id', 'artist', 'notes', 'photo_url', 'albums', 'artist_url')
 
 
 class AlbumSerializer(serializers.HyperlinkedModelSerializer):
     artist = serializers.HyperlinkedRelatedField(
         view_name='artist_detail', read_only=True,
     )
-    artist_string = serializers.CharField(source='artist.artist')
+    artist_string = serializers.CharField(source='artist.artist', read_only=True)
     artist_id = serializers.PrimaryKeyRelatedField(
         queryset=Artist.objects.all(),
         source='artist'


### PR DESCRIPTION
- Add id field to ArtistSerializer so frontend can use it to populate and submit the artist dropdown
- Mark artist_string as read_only on AlbumSerializer to prevent it being required on POST requests
- Update Pipfile Python version from 3.8 to 3.12 to match local environment